### PR TITLE
Raise an error when browser doesn't support performance metrics - such as Firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,29 +14,8 @@ doc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
-#
-# * Create a file at ~/.gitignore
-# * Include files you want ignored
-# * Run: git config --global core.excludesfile ~/.gitignore
-#
-# After doing this, these files will be ignored in all your git projects,
-# saving you from having to 'pollute' every project you touch with them
-#
-# Not sure what to needs to be ignored for particular editors/OSes? Here's some ideas to get you started. (Remember, remove the leading # of the line)
-#
-# For MacOS:
-#
-#.DS_Store
-#
-# For TextMate
-#*.tmproj
-#tmtags
-#
-# For emacs:
-#*~
-#\#*
-#.\#*
-#
-# For vim:
-#*.swp
+# ChromeDriver log
+chromedriver.log
+
+# RubyMine
+.idea

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,2 @@
+rvm_install_on_use_flag=1
+rvm --create use ruby-1.9.2@watir-webdriver

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem "jeweler", "~> 1.5.2"
   gem "rcov", ">= 0"
   gem "zomg", ">= 0"
+  gem "rdoc", ">= 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.1.8)
+    childprocess (0.1.9)
       ffi (~> 1.0.6)
     diff-lcs (1.1.2)
-    ffi (1.0.7)
-      rake (>= 0.8.7)
+    ffi (1.0.9)
     git (1.2.5)
     jeweler (1.5.2)
       bundler (~> 1.0.0)
       git (>= 1.2.5)
       rake
-    json_pure (1.5.1)
-    rake (0.8.7)
+    json_pure (1.5.3)
+    rake (0.9.2)
     rcov (0.9.9)
+    rdoc (3.8)
     rspec (2.3.0)
       rspec-core (~> 2.3.0)
       rspec-expectations (~> 2.3.0)
@@ -28,14 +28,14 @@ GEM
     ruby_parser (2.0.6)
       sexp_processor (~> 3.0)
     rubyzip (0.9.4)
-    selenium-webdriver (0.1.4)
-      childprocess (>= 0.1.7)
+    selenium-webdriver (2.1.0)
+      childprocess (>= 0.1.9)
       ffi (>= 1.0.7)
       json_pure
       rubyzip
     sexp_processor (3.0.5)
-    watir-webdriver (0.2.2)
-      selenium-webdriver (>= 0.1.4)
+    watir-webdriver (0.2.6)
+      selenium-webdriver (>= 0.2.2)
     zomg (1.0.2)
       ruby2ruby
 
@@ -46,6 +46,7 @@ DEPENDENCIES
   bundler (~> 1.0.0)
   jeweler (~> 1.5.2)
   rcov
+  rdoc
   rspec (~> 2.3.0)
   watir-webdriver
   zomg

--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,8 @@ end
 
 task :default => :spec
 
-require 'rake/rdoctask'
-Rake::RDocTask.new do |rdoc|
+require 'rdoc/task'
+RDoc::Task.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 
   rdoc.rdoc_dir = 'rdoc'

--- a/lib/watir-webdriver-performance.rb
+++ b/lib/watir-webdriver-performance.rb
@@ -77,6 +77,7 @@ module Watir
   class Browser
     def performance
       data = driver.execute_script("return window.performance || window.webkitPerformance || window.mozPerformance || window.msPerformance;")
+      raise 'Could not collect performance metrics from your current browser. Please ensure the browser you are using supports collecting performance metrics.' if data.nil?
       PerformanceHelper.new(data).munge
     end
   end

--- a/spec/watir-webdriver-performance-non-supported-browser_spec.rb
+++ b/spec/watir-webdriver-performance-non-supported-browser_spec.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe "WatirWebdriverPerformance-NonSupportedBrowser" do
+
+  let!(:b) { @b }
+
+  before(:all) do
+    @b ||= Watir::Browser.new :firefox
+  end
+
+  after(:all) do
+    @b.close
+  end
+
+  it "should raise an error when a non supported browser is encountered" do
+    b.goto "google.com"
+    lambda {  b.performance }.should raise_error RuntimeError, 'Could not collect performance metrics from your current browser. Please ensure the browser you are using supports collecting performance metrics.'
+  end
+
+end


### PR DESCRIPTION
- Raise an error when browser metrics are not supported
- Added spec for this
- Updated to latest watir-webdriver and selenium-webdriver versions
- Added .rvmrc file for RVM
- Fixed Rdoc deprecated method
- Redirect spec is still failing - not sure why
