### PR TITLE
Added two methods to browser

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,2 @@
 rvm_install_on_use_flag=1
-rvm --create use ruby-1.9.2@watir-webdriver
+rvm --create use ruby-1.9.2@watir-webdriver-performance

--- a/lib/watir-webdriver-performance.rb
+++ b/lib/watir-webdriver-performance.rb
@@ -80,6 +80,15 @@ module Watir
       raise 'Could not collect performance metrics from your current browser. Please ensure the browser you are using supports collecting performance metrics.' if data.nil?
       PerformanceHelper.new(data).munge
     end
+
+    def performance_supported?
+      driver.execute_script("return window.performance || window.webkitPerformance || window.mozPerformance || window.msPerformance;")
+    end
+    alias performance_data performance_supported?
+
+    def with_performance
+       yield PerformanceHelper.new(performance_data).munge if performance_supported?
+    end
   end
 end
 

--- a/spec/watir-webdriver-performance-non-supported-browser_spec.rb
+++ b/spec/watir-webdriver-performance-non-supported-browser_spec.rb
@@ -17,4 +17,13 @@ describe "WatirWebdriverPerformance-NonSupportedBrowser" do
     lambda {  b.performance }.should raise_error RuntimeError, 'Could not collect performance metrics from your current browser. Please ensure the browser you are using supports collecting performance metrics.'
   end
 
+  it "should return false for firefox supported" do
+    b.goto "google.com"
+    b.should_not be_performance_supported
+  end
+
+  it "should not support performance as block" do
+    b.goto "google.com"
+    b.with_performance {|performance| performance.should be_nil }
+  end
 end

--- a/spec/watir-webdriver-performance_spec.rb
+++ b/spec/watir-webdriver-performance_spec.rb
@@ -44,4 +44,13 @@ describe "WatirWebdriverPerformance" do
     puts "Page took #{b.performance.summary[:response_time]/1000} seconds to load"
   end
 
+  it "should return true for chrome supported" do
+    b.goto "google.com"
+    b.should be_performance_supported
+  end
+
+  it "should support performance as block" do
+    b.goto "google.com"
+    b.with_performance {|performance| performance.should_not be_nil }
+  end
 end


### PR DESCRIPTION
Added two methods to browser: performance_supported? and with_performance with associated specs.

performance_supported?: can check whether the browser supports performance metrics
with_performance: allows you to use performance as a block

Added associated specs to test each of these methods

Minor: updated .rvmrc to use new gemset
