### PR TITLE
Fixed a crash in lastest Chrome

### DIFF
--- a/lib/watir-webdriver-performance.rb
+++ b/lib/watir-webdriver-performance.rb
@@ -17,6 +17,7 @@ module Watir
           next
         end
         hash[key.to_sym] = {}
+        next unless @data[key].respond_to? :each
         @data[key].each do |k,v|
           if k == '__fxdriver_unwrapped'
             next


### PR DESCRIPTION
Currently browser.performance crashes with error "NoMethodError Exception: undefined method `respond_to' for "function webkitNow() { [native code] }":String" in Ruby 1.9.3

This commit fixes this behaviour - we should ensure that value can be enumerated
