### PR TITLE
Fix bug of calculation for redirect time in summary.

### DIFF
--- a/lib/watir-webdriver-performance.rb
+++ b/lib/watir-webdriver-performance.rb
@@ -25,10 +25,10 @@ module Watir
           hash[key.to_sym][underscored(k).to_sym] = v
         end
       end
-      
+
       hash[:summary] = {}
       hash[:summary][:redirect] = hash[:timing][:redirect_end] -
-        hash[:timing][:redirect_end] if hash[:timing][:redirect_end] > 0
+        hash[:timing][:redirect_start] if hash[:timing][:redirect_end] > 0
       hash[:summary][:app_cache] = hash[:timing][:domain_lookup_start] -
         hash[:timing][:fetch_start] if hash[:timing][:fetch_start] > 0
       hash[:summary][:dns] = hash[:timing][:domain_lookup_end] -
@@ -36,8 +36,8 @@ module Watir
       hash[:summary][:tcp_connection] = hash[:timing][:connect_end] -
         hash[:timing][:connect_start] if hash[:timing][:connect_start] > 0
       hash[:summary][:tcp_connection_secure] = hash[:timing][:connect_end] -
-        hash[:timing][:secure_connection_start] if 
-          ((hash[:timing][:secure_connection_start] != nil) and 
+        hash[:timing][:secure_connection_start] if
+          ((hash[:timing][:secure_connection_start] != nil) and
            (hash[:timing][:secure_connection_start] > 0))
       hash[:summary][:request] = hash[:timing][:response_start] -
         hash[:timing][:request_start] if hash[:timing][:request_start] > 0


### PR DESCRIPTION
In PerformanceHelper#munge, redirect time was calculated according to the following expresion.

``` ruby
hash[:summary][:redirect] = hash[:timing][:redirect_end] - hash[:timing][:redirect_end]
```

so the redirect time is always zero.

I fixed this to

``` ruby
hash[:summary][:redirect] = hash[:timing][:redirect_end] - hash[:timing][:redirect_start]
```
